### PR TITLE
Update install-dnsmasq

### DIFF
--- a/modules/install-dnsmasq/install-dnsmasq
+++ b/modules/install-dnsmasq/install-dnsmasq
@@ -106,7 +106,8 @@ function write_consul_config {
 # Enable forward lookup of the '$consul_domain' domain:
 server=/${consul_domain}/${consul_ip}#${consul_port}
 
-listen-address=${consul_ip}
+# listen-address=${consul_ip}
+interface=eth0
 bind-interfaces
 EOF
 }


### PR DESCRIPTION
In order to resolve *.consul domain without consul client (via DNS port 53), we need to configure DNSMASQ to listen interface instead of local ip (127.0.0.1)